### PR TITLE
Update Python path for MunkiCatalogPromote.py

### DIFF
--- a/MunkiCatalogPromote.py
+++ b/MunkiCatalogPromote.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/Python.framework/Versions/Current/bin/python3
+#!/usr/local/munki/munki-python
 
 import datetime
 import logging


### PR DESCRIPTION
Munki no longer uses `/usr/local/munki/python`, so this PR updates for the new path.